### PR TITLE
🚀 [Feature]: Update `Set-MarkdownCodeBlock` to optionally execute the command and use the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ Import-Module -Name Markdown
 The `Markdown` module introduces a Domain Specific Language (DSL) that simplifies the creation of Markdown files. With straightforward commands, you
 can generate headings, details blocks, fenced code blocks, and tables without manually formatting Markdown.
 
-### DSL Syntax Overview
-
-#### Heading
+### Heading
 
 Create Markdown headings by specifying the level, title, and content.
 
@@ -62,7 +60,43 @@ Content under the title
 Content under the nested title
 ```
 
-#### Details
+### Paragraph
+
+Create a paragraph of text.
+
+```powershell
+Paragraph {
+    'This is a paragraph'
+}
+```
+
+This produces:
+
+```markdown
+
+This is a paragraph
+
+```
+
+Supports tags for inline formatting.
+
+```powershell
+Paragraph {
+    'This is a paragraph with tags'
+} -Tags
+```
+
+This produces:
+
+```markdown
+<p>
+
+This is a paragraph with tags
+
+</p>
+```
+
+### Details
 
 Generate collapsible sections with a summary title.
 
@@ -117,7 +151,7 @@ Nested content goes here
 ```
 
 
-#### CodeBlock
+### CodeBlock
 
 Create fenced code blocks for any programming language.
 
@@ -159,7 +193,7 @@ Jane Doe  25
 ```
 ````
 
-#### Table
+### Table
 
 Convert a collection of PowerShell objects into a Markdown table.
 

--- a/README.md
+++ b/README.md
@@ -20,69 +20,166 @@ can generate headings, details blocks, fenced code blocks, and tables without ma
 
 ### DSL Syntax Overview
 
-- **Heading**
-  Create Markdown headings by specifying the level, title, and content. For example:
-  ```powershell
-  Heading 1 'Title' {
-      'Content under the title'
-  }
-  ```
-  This produces:
-  ```markdown
-  # Title
+#### Heading
 
-  Content under the title
-  ```
+Create Markdown headings by specifying the level, title, and content.
 
-- **Details**
-  Generate collapsible sections with a summary title:
-  ```powershell
-  Details 'More Information' {
-      'Detailed content goes here'
-  }
-  ```
-  Which outputs:
-  ```markdown
-  <details><summary>More Information</summary>
-  <p>
+```powershell
+Heading 1 'Title' {
+    'Content under the title'
+}
+```
 
-  Detailed content goes here
+This produces:
 
-  </p>
-  </details>
-  ```
+```markdown
+# Title
 
-- **CodeBlock**
-  Create fenced code blocks for any programming language:
-  ```powershell
-  CodeBlock 'powershell' {
-      Get-Process
-  }
-  ```
-  Yielding:
-  ````markdown
-  ```powershell
-  Get-Process
-  ```
-  ````
+Content under the title
+```
 
-- **Table**
-  Convert a collection of PowerShell objects into a Markdown table:
-  ```powershell
-  Table {
-      @(
-          [PSCustomObject]@{ Name = 'John Doe'; Age = 30 }
-          [PSCustomObject]@{ Name = 'Jane Doe'; Age = 25 }
-      )
-  }
-  ```
-  Which results in:
-  ```markdown
-  | Name | Age |
-  | - | - |
-  | John Doe | 30 |
-  | Jane Doe | 25 |
-  ```
+Supports nested headings.
+
+```powershell
+Heading 1 'Title' {
+    'Content under the title'
+
+    Heading 2 'Nested Title' {
+        'Content under the nested title'
+    }
+}
+```
+
+This produces:
+
+```markdown
+# Title
+
+Content under the title
+
+## Nested Title
+
+Content under the nested title
+```
+
+#### Details
+
+Generate collapsible sections with a summary title.
+
+```powershell
+Details 'More Information' {
+    'Detailed content goes here'
+}
+```
+
+This produces:
+
+```markdown
+<details><summary>More Information</summary>
+<p>
+
+Detailed content goes here
+
+</p>
+</details>
+```
+
+Supports nested details blocks.
+
+```powershell
+Details 'More Information' {
+    'Detailed content goes here'
+
+    Details 'Nested Information' {
+        'Nested content goes here'
+    }
+}
+```
+
+This produces:
+
+```markdown
+<details><summary>More Information</summary>
+<p>
+
+Detailed content goes here
+
+<details><summary>Nested Information</summary>
+<p>
+
+Nested content goes here
+
+</p>
+</details>
+
+</p>
+</details>
+```
+
+
+#### CodeBlock
+
+Create fenced code blocks for any programming language.
+
+```powershell
+CodeBlock 'powershell' {
+    Get-Process
+}
+```
+
+This produces:
+
+````markdown
+```powershell
+Get-Process
+```
+````
+
+It can also execute PowerShell code directly and use the output in the code block (using the `-Execute` switch).
+
+```powershell
+CodeBlock 'powershell' {
+    @(
+        [PSCustomObject]@{ Name = 'John Doe'; Age = 30 }
+        [PSCustomObject]@{ Name = 'Jane Doe'; Age = 25 }
+    )
+} -Execute
+```
+
+This produces:
+
+````markdown
+```powershell
+
+Name     Age
+----     ---
+John Doe  30
+Jane Doe  25
+
+```
+````
+
+#### Table
+
+Convert a collection of PowerShell objects into a Markdown table.
+
+```powershell
+Table {
+    @(
+        [PSCustomObject]@{ Name = 'John Doe'; Age = 30 }
+        [PSCustomObject]@{ Name = 'Jane Doe'; Age = 25 }
+    )
+}
+```
+
+This produces:
+
+```markdown
+| Name | Age |
+| - | - |
+| John Doe | 30 |
+| Jane Doe | 25 |
+```
 
 ### Example: Full Markdown Document Generation
 
@@ -106,7 +203,20 @@ Heading 1 'This is the section title' {
                 'Some string content here too'
             }
         }
+
+        Paragraph {
+            'This is a paragraph'
+        } -Tags
+
+        'This is the end of the section'
     }
+
+    CodeBlock 'powershell' {
+        @(
+            [PSCustomObject]@{ Name = 'John Doe'; Age = 30 }
+            [PSCustomObject]@{ Name = 'Jane Doe'; Age = 25 }
+        )
+    } -Execute
 
     Table {
         @(
@@ -115,7 +225,8 @@ Heading 1 'This is the section title' {
         )
     }
 
-    'This is the end of the section'
+
+    'This is the end of the document'
 }
 ```
 
@@ -132,7 +243,6 @@ Some string content here too
 <p>
 
 Some string content here
-
 ```powershell
 Get-Process
 ```
@@ -148,12 +258,32 @@ Some string content here too
 </p>
 </details>
 
+
+<p>
+
+This is a paragraph
+
+</p>
+
+This is the end of the section
+
+```powershell
+
+Name     Age
+----     ---
+John Doe  30
+Jane Doe  25
+
+
+```
+
 | Name | Age |
 | - | - |
 | John Doe | 30 |
 | Jane Doe | 25 |
 
-This is the end of the section
+This is the end of the document
+
 ````
 
 ## Contributing

--- a/src/functions/public/Set-MarkdownCodeBlock.ps1
+++ b/src/functions/public/Set-MarkdownCodeBlock.ps1
@@ -4,9 +4,9 @@
         Generates a fenced code block for Markdown using the specified language.
 
         .DESCRIPTION
-        This function takes a programming language and a script block, captures the script block’s contents,
-        normalizes the indentation, removes the outer braces (if present) and then formats it as a fenced code
-        block suitable for Markdown.
+        This function takes a programming language and a script block, and depending on the provided parameters,
+        either captures the script block's literal text (with indentation normalized) or executes it and captures the
+        string representation of the output. It then formats the result as a fenced code block suitable for Markdown.
 
         .EXAMPLE
         Set-MarkdownCodeBlock -Language 'powershell' -Content {
@@ -32,6 +32,20 @@
 
         Generates a fenced code block with the specified PowerShell script.
 
+        .EXAMPLE
+        CodeBlock -Language 'powershell' -Content {
+            Get-Process | Select-Object -First 1
+        } -Execute
+
+        Output:
+        ```powershell
+        NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
+        ------    -----      -----     ------      --  -- -----------
+            13     4.09      15.91       0.00    9904   0 AggregatorHost
+        ```
+
+        Generates a fenced code block with the output of the specified PowerShell script.
+
         .OUTPUTS
         string
 
@@ -53,42 +67,54 @@
     [CmdletBinding()]
     param(
         [Parameter(Mandatory, Position = 0)]
-        [string]$Language,
+        [string] $Language,
 
         [Parameter(Mandatory, Position = 1)]
-        [scriptblock]$Content
+        [scriptblock] $Content,
+
+        [Parameter()]
+        [switch] $Execute
     )
 
-    # Capture the raw text of the script block
-    $raw = $Content.Ast.Extent.Text
-    $lines = $raw -split "`r?`n"
+    # If -Execute is specified, run the script block and capture its output.
+    if ($Execute) {
+        # Execute the script block and capture all output as a single string.
+        $output = . $Content | Out-String
+        # Split the output into lines.
+        $lines = $output -split "`r?`n"
+    } else {
+        # Capture the raw text of the script block.
+        $raw = $Content.Ast.Extent.Text
+        $lines = $raw -split "`r?`n"
 
-    # Remove leading and trailing blank lines
-    while ($lines.Count -gt 0 -and $lines[0].Trim() -eq '') {
-        $lines = $lines[1..($lines.Count - 1)]
-    }
-    while ($lines.Count -gt 0 -and $lines[-1].Trim() -eq '') {
-        $lines = $lines[0..($lines.Count - 2)]
-    }
+        # Remove leading and trailing blank lines.
+        while ($lines.Count -gt 0 -and $lines[0].Trim() -eq '') {
+            $lines = $lines[1..($lines.Count - 1)]
+        }
+        while ($lines.Count -gt 0 -and $lines[-1].Trim() -eq '') {
+            $lines = $lines[0..($lines.Count - 2)]
+        }
 
-    # If the first and last lines are only '{' and '}', remove them.
-    if ($lines.Count -ge 2 -and $lines[0].Trim() -eq '{' -and $lines[-1].Trim() -eq '}') {
-        $lines = $lines[1..($lines.Count - 2)]
-    }
+        # If the first and last lines are only '{' and '}', remove them.
+        if ($lines.Count -ge 2 -and $lines[0].Trim() -eq '{' -and $lines[-1].Trim() -eq '}') {
+            $lines = $lines[1..($lines.Count - 2)]
+        }
 
-    # Determine common leading whitespace (indentation) on non-empty lines
-    $nonEmpty = $lines | Where-Object { $_.Trim().Length -gt 0 }
-    if ($nonEmpty) {
-        $commonIndent = ($nonEmpty | ForEach-Object {
-                $_.Length - $_.TrimStart().Length
-            } | Measure-Object -Minimum).Minimum
+        # Determine common leading whitespace (indentation) on non-empty lines.
+        $nonEmpty = $lines | Where-Object { $_.Trim().Length -gt 0 }
+        if ($nonEmpty) {
+            $commonIndent = ($nonEmpty | ForEach-Object {
+                    $_.Length - $_.TrimStart().Length
+                } | Measure-Object -Minimum).Minimum
 
-        # Remove the common indent from each line
-        $lines = $lines | ForEach-Object {
-            if ($_.Length -ge $commonIndent) { $_.Substring($commonIndent) } else { $_ }
+            # Remove the common indent from each line.
+            $lines = $lines | ForEach-Object {
+                if ($_.Length -ge $commonIndent) { $_.Substring($commonIndent) } else { $_ }
+            }
         }
     }
 
+    # Build the Markdown fenced code block.
     $return = @()
     $return += '```{0}' -f $Language
     $return += $lines

--- a/tests/Markdown.Tests.ps1
+++ b/tests/Markdown.Tests.ps1
@@ -147,31 +147,45 @@ This is a simple Markdown paragraph generated dynamically.
         It 'Can write a markdown doc as DSL' {
             $content = Heading 1 'This is the section title' {
                 'Some string content here'
+
                 Heading 2 'Should be able to call nested sections' {
                     'Some string content here too'
+
                     Details 'This is the detail title' {
                         'Some string content here'
+
                         CodeBlock 'powershell' {
                             Get-Process
                         }
+
                         Details 'Should be able to call nested details' {
                             'Some string content here too'
                         }
                     }
+
+                    Paragraph {
+                        'This is a paragraph'
+                    } -Tags
+
+                    'This is the end of the section'
                 }
+
+                CodeBlock 'powershell' {
+                    @(
+                        [PSCustomObject]@{ Name = 'John Doe'; Age = 30 }
+                        [PSCustomObject]@{ Name = 'Jane Doe'; Age = 25 }
+                    )
+                } -Execute
+
                 Table {
                     @(
-                        [PSCustomObject]@{
-                            Name = 'John Doe'
-                            Age  = 30
-                        }
-                        [PSCustomObject]@{
-                            Name = 'Jane Doe'
-                            Age  = 25
-                        }
+                        [PSCustomObject]@{ Name = 'John Doe'; Age = 30 }
+                        [PSCustomObject]@{ Name = 'Jane Doe'; Age = 25 }
                     )
                 }
-                'This is the end of the section'
+
+
+                'This is the end of the document'
             }
 
             $expected = @'
@@ -200,12 +214,31 @@ Some string content here too
 </p>
 </details>
 
+
+<p>
+
+This is a paragraph
+
+</p>
+
+This is the end of the section
+
+```powershell
+
+Name     Age
+----     ---
+John Doe  30
+Jane Doe  25
+
+
+```
+
 | Name | Age |
 | - | - |
 | John Doe | 30 |
 | Jane Doe | 25 |
 
-This is the end of the section
+This is the end of the document
 
 '@
             $content | Should -Be $expected

--- a/tests/Markdown.Tests.ps1
+++ b/tests/Markdown.Tests.ps1
@@ -86,6 +86,28 @@ Get-Process
 '@
             $content | Should -Be $expected
         }
+
+        It 'Can execute and render a code block with PowerShell code' {
+            $content = Set-MarkdownCodeBlock -Language 'powershell' -Content {
+                [PSCustomObject]@{
+                    Name = 'John Doe'
+                    Age  = 30
+                }
+            } -Execute
+
+            $expected = @'
+```powershell
+
+Name     Age
+----     ---
+John Doe  30
+
+
+```
+
+'@
+            $content | Should -Be $expected
+        }
     }
 
     Context 'Set-MarkdownParagraph' {


### PR DESCRIPTION
## Description

This pull request updates the `Set-MarkdownCodeBlock` function to execute a script block and capture its output for inclusion in a Markdown code block.

### Enhancements to `Set-MarkdownCodeBlock` function:

* Added a new parameter `-Execute` to control whether the script block should be executed or its literal text captured.

### Updates to tests

* Added a new test case to validate that the `Set-MarkdownCodeBlock` function correctly executes a script block and renders the output as a fenced code block.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
