### PR TITLE
🪲 [Fix]: Update test to adjust output rendering

### DIFF
--- a/tests/Markdown.Tests.ps1
+++ b/tests/Markdown.Tests.ps1
@@ -9,6 +9,10 @@
 [CmdletBinding()]
 param()
 
+BeforeAll {
+    $PSStyle.OutputRendering = 'Host'
+}
+
 Describe 'Module' {
     Context 'Set-MarkdownSection' {
         It 'Can render a #2 heading with a paragraph' {
@@ -244,4 +248,8 @@ This is the end of the document
             $content | Should -Be $expected
         }
     }
+}
+
+AfterAll {
+    $PSStyle.OutputRendering = 'Ansi'
 }


### PR DESCRIPTION
## Description

This pull request includes a small change to the `tests/Markdown.Tests.ps1` file. The change configures the PowerShell output rendering style before and after running tests to ensure consistent output formatting. This to ensure that comparison can be done without counting in rendering.

* Added `BeforeAll` block to set `$PSStyle.OutputRendering` to 'Host' before tests run.
* Added `AfterAll` block to reset `$PSStyle.OutputRendering` to 'Ansi' after tests complete.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
