### PR TITLE
🪲 [Fix]: Fix linter settings and docs

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,12 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false

--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,13 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -8,18 +8,19 @@
 ###############
 # Rules by id #
 ###############
-MD004: false                  # Unordered list style
+MD004: false # Unordered list style
 MD007:
-  indent: 2                   # Unordered list indentation
+  indent: 2 # Unordered list indentation
 MD013:
-  line_length: 808            # Line length
+  line_length: 808 # Line length
+MD024: false # no-duplicate-heading, INPUTS and OUTPUTS _can_ be the same item
 MD026:
-  punctuation: ".,;:!。，；:"  # List of not allowed
-MD029: false                  # Ordered list item prefix
-MD033: false                  # Allow inline HTML
-MD036: false                  # Emphasis used instead of a heading
+  punctuation: '.,;:!。，；:' # List of not allowed
+MD029: false # Ordered list item prefix
+MD033: false # Allow inline HTML
+MD036: false # Emphasis used instead of a heading
 
 #################
 # Rules by tags #
 #################
-blank_lines: false  # Error on blank lines
+blank_lines: false # Error on blank lines

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Nested content goes here
 Create fenced code blocks for any programming language.
 
 ```powershell
-CodeBlock 'powershell' {
+CodeBlock 'PowerShell' {
     Get-Process
 }
 ```
@@ -172,7 +172,7 @@ Get-Process
 It can also execute PowerShell code directly and use the output in the code block (using the `-Execute` switch).
 
 ```powershell
-CodeBlock 'powershell' {
+CodeBlock 'PowerShell' {
     @(
         [PSCustomObject]@{ Name = 'John Doe'; Age = 30 }
         [PSCustomObject]@{ Name = 'Jane Doe'; Age = 25 }
@@ -229,7 +229,7 @@ Heading 1 'This is the section title' {
         Details 'This is the detail title' {
             'Some string content here'
 
-            CodeBlock 'powershell' {
+            CodeBlock 'PowerShell' {
                 Get-Process
             }
 
@@ -245,7 +245,7 @@ Heading 1 'This is the section title' {
         'This is the end of the section'
     }
 
-    CodeBlock 'powershell' {
+    CodeBlock 'PowerShell' {
         @(
             [PSCustomObject]@{ Name = 'John Doe'; Age = 30 }
             [PSCustomObject]@{ Name = 'Jane Doe'; Age = 25 }

--- a/examples/General.ps1
+++ b/examples/General.ps1
@@ -7,7 +7,7 @@
         Details 'This is the detail title' {
             'Some string content here'
 
-            CodeBlock 'powershell' {
+            CodeBlock 'PowerShell' {
                 Get-Process
             }
 

--- a/src/functions/public/Set-MarkdownCodeBlock.ps1
+++ b/src/functions/public/Set-MarkdownCodeBlock.ps1
@@ -9,7 +9,7 @@
         string representation of the output. It then formats the result as a fenced code block suitable for Markdown.
 
         .EXAMPLE
-        Set-MarkdownCodeBlock -Language 'powershell' -Content {
+        Set-MarkdownCodeBlock -Language 'PowerShell' -Content {
             Get-Process
         }
 
@@ -21,7 +21,7 @@
         Generates a fenced code block with the specified PowerShell script.
 
         .EXAMPLE
-        CodeBlock 'powershell' {
+        CodeBlock 'PowerShell' {
             Get-Process
         }
 
@@ -33,7 +33,7 @@
         Generates a fenced code block with the specified PowerShell script.
 
         .EXAMPLE
-        CodeBlock -Language 'powershell' -Content {
+        CodeBlock -Language 'PowerShell' -Content {
             Get-Process | Select-Object -First 1
         } -Execute
 

--- a/tests/Markdown.Tests.ps1
+++ b/tests/Markdown.Tests.ps1
@@ -78,7 +78,7 @@ This is detailed content.
 
     Context 'Set-MarkdownCodeBlock' {
         It 'Can render a code block with PowerShell code' {
-            $content = Set-MarkdownCodeBlock -Language 'powershell' -Content {
+            $content = Set-MarkdownCodeBlock -Language 'PowerShell' -Content {
                 Get-Process
             }
 
@@ -92,7 +92,7 @@ Get-Process
         }
 
         It 'Can execute and render a code block with PowerShell code' {
-            $content = Set-MarkdownCodeBlock -Language 'powershell' -Content {
+            $content = Set-MarkdownCodeBlock -Language 'PowerShell' -Content {
                 [PSCustomObject]@{
                     Name = 'John Doe'
                     Age  = 30
@@ -158,7 +158,7 @@ This is a simple Markdown paragraph generated dynamically.
                     Details 'This is the detail title' {
                         'Some string content here'
 
-                        CodeBlock 'powershell' {
+                        CodeBlock 'PowerShell' {
                             Get-Process
                         }
 
@@ -174,7 +174,7 @@ This is a simple Markdown paragraph generated dynamically.
                     'This is the end of the section'
                 }
 
-                CodeBlock 'powershell' {
+                CodeBlock 'PowerShell' {
                     @(
                         [PSCustomObject]@{ Name = 'John Doe'; Age = 30 }
                         [PSCustomObject]@{ Name = 'Jane Doe'; Age = 25 }


### PR DESCRIPTION
This pull request introduces updates to the linter configurations for both YAML and Markdown files. The main changes focus on customizing which linters are run and adjusting Markdown linting rules for greater flexibility.

Linter configuration updates:

* [`.github/PSModule.yml`](diffhunk://#diff-928165ed381f1982eb8f9746a59a2829db4abc8a28eddb8c109e12bb033ff96aR22-R31): Added a `Linter` section to the configuration, explicitly disabling several validation checks (e.g., `VALIDATE_BIOME_FORMAT`, `VALIDATE_JSCPD`, `VALIDATE_JSON_PRETTIER`, etc.) by setting their environment variables to `false`.

Markdown linting rule adjustments:

* [`.github/linters/.markdown-lint.yml`](diffhunk://#diff-2fd3619d2b7372123257bc21645edb90c24293e66babbc6053033a89e21bab34R16-R18): Disabled the `MD024` rule (no duplicate headings) to allow repeated headings such as INPUTS and OUTPUTS, and made a minor formatting fix to the `MD026` punctuation list.